### PR TITLE
Bump minor versions of images

### DIFF
--- a/images/coblox_bitcoincore/Cargo.toml
+++ b/images/coblox_bitcoincore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_coblox_bitcoincore"
-version = "0.1.1"
+version = "0.2.0"
 authors = [
     "Thomas Eizinger <thomas@coblox.tech>",
     "Philipp Hoenisch <philipp@coblox.tech>",

--- a/images/trufflesuite_ganachecli/Cargo.toml
+++ b/images/trufflesuite_ganachecli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tc_trufflesuite_ganachecli"
-version = "0.1.1"
+version = "0.2.0"
 authors = [
     "Thomas Eizinger <thomas@coblox.tech>",
     "Philipp Hoenisch <philipp@coblox.tech>",


### PR DESCRIPTION
Increasing the version of the testcontainers dependency is actually a
breaking changes, thus we have to bump the minor version.